### PR TITLE
Temporarily disable code signing to test CI pipeline (Clean)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,12 +217,13 @@ jobs:
             cp *.rdmp $platform
           done
           rm *.rdmp
-      - name: Sign & zip
+      - name: Zip artifacts (code signing disabled)
         shell: bash
         run: |
-          dotnet tool install --global AzureSignTool 
-          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v PublishWindows/rdmp.exe
-          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v PublishWinForms/ResearchDataManagementPlatform.exe
+          # Code signing has been temporarily disabled to test CI pipeline
+          # dotnet tool install --global AzureSignTool
+          # AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v PublishWindows/rdmp.exe
+          # AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v PublishWinForms/ResearchDataManagementPlatform.exe
           mkdir -p dist
           (cd PublishWindows ; echo 7z a -mx=9 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-cli-win-x64.zip . | cmd)
           (cd PublishLinux ; echo 7z a -mx=0 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-cli-linux-x64.zip . | cmd)


### PR DESCRIPTION
## Summary
- Temporarily disabled code signing in GitHub Actions build workflow
- Commented out AzureSignTool commands that were causing potential CI issues
- Renamed the build step from "Sign & zip" to "Zip artifacts (code signing disabled)"

## Changes Made
- Modified `.github/workflows/build.yml` to comment out AzureSignTool installation and signing commands
- Preserved all other build functionality (artifact creation, packaging, etc.)
- Added clear comments explaining that code signing is temporarily disabled

## Test Plan
- [ ] Verify that CI pipeline runs without code signing errors
- [ ] Confirm that all build artifacts are generated correctly
- [ ] Test that generated executables work as expected (though unsigned)
- [ ] Monitor CI build times to see if removing signing improves performance

## Context
This PR is intended to diagnose whether the code signing process is causing CI failures. Once CI is confirmed to be working without signing, we can either:
1. Re-enable code signing if it wasn't the issue
2. Investigate and fix the code signing configuration if it was the root cause

The code signing can be re-enabled by uncommenting the AzureSignTool commands in the workflow.

**Note:** This is a clean branch based directly on develop, containing only the code signing changes.