### PR TITLE
Add generic overloads to AotObjectConstructor

### DIFF
--- a/Rdmp.Core/Repositories/Construction/AotObjectConstructor.cs
+++ b/Rdmp.Core/Repositories/Construction/AotObjectConstructor.cs
@@ -170,9 +170,10 @@ public static class AotObjectConstructor
     /// <typeparam name="T">The return type (may be wider than t, e.g., an interface)</typeparam>
     /// <param name="t">The concrete type to construct</param>
     /// <param name="serviceLocator">The service locator parameter</param>
+    /// <param name="allowBlank">Whether to allow blank constructors</param>
     /// <returns>A new instance of the specified type cast to T</returns>
-    public static T Construct<T>(Type t, IRDMPPlatformRepositoryServiceLocator serviceLocator) where T : class
-        => (T)Construct(t, serviceLocator);
+    public static T Construct<T>(Type t, IRDMPPlatformRepositoryServiceLocator serviceLocator, bool allowBlank = true) where T : class
+        => (T)Construct(t, serviceLocator, allowBlank);
 
     /// <summary>
     /// Attempts to construct an instance of Type t using the provided constructorValues,
@@ -182,8 +183,9 @@ public static class AotObjectConstructor
     /// <param name="t">The concrete type to construct</param>
     /// <param name="constructorValues">Constructor parameter values</param>
     /// <returns>A new instance cast to T, or null if no compatible constructor was found</returns>
+    /// <exception cref="InvalidCastException">Thrown if construction succeeds but the result cannot be cast to T</exception>
     public static T ConstructIfPossible<T>(Type t, params object[] constructorValues) where T : class
-        => ConstructIfPossible(t, constructorValues) as T;
+        => (T)ConstructIfPossible(t, constructorValues);
 
     #endregion
 


### PR DESCRIPTION
## Summary

Add three generic overloads to `AotObjectConstructor` for better type safety:

- `Construct<T>(Type t) where T : class`
- `Construct<T>(Type t, IRDMPPlatformRepositoryServiceLocator serviceLocator) where T : class`
- `ConstructIfPossible<T>(Type t, params object[] constructorValues) where T : class`

These allow callers to avoid explicit casts when the expected type is known at compile time.

Note: T may be wider than t, supporting patterns like:
```csharp
var thing = Construct<IThing>(typeof(SpecificThing));
```

## Test plan

- [ ] Build passes
- [ ] Existing tests pass (no breaking changes - these are additive)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added three generic overloads to AotObjectConstructor that return T instead of object: Construct<T>(Type), Construct<T>(Type, IRDMPPlatformRepositoryServiceLocator, bool allowBlank = true), and ConstructIfPossible<T>(Type, params object[]). This improves type safety, supports constructing as an interface or base type, and fails fast on type mismatches.

<sup>Written for commit 1948eb88903f73b1204b7de079ba820eacd560fb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds three generic overloads to the `AotObjectConstructor` class to improve type safety by allowing callers to specify the expected return type at compile time and avoid explicit casts. The new methods `Construct<T>(Type)`, `Construct<T>(Type, IRDMPPlatformRepositoryServiceLocator)`, and `ConstructIfPossible<T>(Type, params object[])` wrap existing non-generic methods and support covariant patterns where the generic type parameter can be a base class or interface of the concrete type being constructed.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Rdmp.Core/Repositories/Construction/AotObjectConstructor.cs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->