### PR TITLE
Use FrozenDictionary for MemoryRepository type storage

### DIFF
--- a/Rdmp.Core/MapsDirectlyToDatabaseTable/MemoryRepository.cs
+++ b/Rdmp.Core/MapsDirectlyToDatabaseTable/MemoryRepository.cs
@@ -29,9 +29,10 @@ public class MemoryRepository : IRepository
 
     /// <summary>
     /// Type-indexed storage for O(1) lookups: Type -> (ID -> Object)
-    /// Pre-populated with all compatible types at construction, then frozen for optimal read performance.
+    /// Pre-populated with all compatible types at construction for optimal read performance.
+    /// Additional types (e.g., Spontaneous objects) can be added dynamically.
     /// </summary>
-    private readonly FrozenDictionary<Type, ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>> _objectsByType;
+    private readonly ConcurrentDictionary<Type, ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>> _objectsByType;
 
     /// <summary>
     /// Precomputed type hierarchy: Interface/BaseClass -> ConcreteTypes[]
@@ -77,13 +78,11 @@ public class MemoryRepository : IRepository
         _compatibleTypes = BuildCompatibleTypes();
 
         // Pre-populate type storage with empty dictionaries for all compatible types
-        var typeStorage = new Dictionary<Type, ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>>(
-            _compatibleTypes.Length);
+        _objectsByType = new ConcurrentDictionary<Type, ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>>();
         foreach (var type in _compatibleTypes)
         {
-            typeStorage[type] = new ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>();
+            _objectsByType[type] = new ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>();
         }
-        _objectsByType = typeStorage.ToFrozenDictionary();
 
         // Build type hierarchy once at construction
         _typeHierarchy = BuildTypeHierarchy(_compatibleTypes);
@@ -151,7 +150,7 @@ public class MemoryRepository : IRepository
 
     /// <summary>
     /// Get the type-specific dictionary for a given type.
-    /// Returns null if type is not a compatible type.
+    /// Returns null if type is not known to this repository.
     /// </summary>
     protected ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable> GetTypeDictionary(Type type)
     {
@@ -159,15 +158,13 @@ public class MemoryRepository : IRepository
     }
 
     /// <summary>
-    /// Get the type-specific dictionary for a compatible type.
-    /// Throws if the type is not compatible with this repository.
+    /// Get or create the type-specific dictionary for a given type.
+    /// Creates dictionary for types not in the pre-populated list (e.g., Spontaneous objects).
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when type is not compatible.</exception>
     [NotNull]
-    protected ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable> GetTypeDictionaryOrThrow(Type type)
+    protected ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable> GetOrCreateTypeDictionary(Type type)
     {
-        return _objectsByType.GetValueOrDefault(type)
-            ?? throw new InvalidOperationException($"Type {type.Name} is not a compatible type for this repository");
+        return _objectsByType.GetOrAdd(type, _ => new ConcurrentDictionary<int, IMapsDirectlyToDatabaseTable>());
     }
 
     /// <summary>
@@ -175,7 +172,7 @@ public class MemoryRepository : IRepository
     /// </summary>
     private bool AddToTypeIndex(IMapsDirectlyToDatabaseTable obj)
     {
-        return GetTypeDictionaryOrThrow(obj.GetType()).TryAdd(obj.ID, obj);
+        return GetOrCreateTypeDictionary(obj.GetType()).TryAdd(obj.ID, obj);
     }
 
     /// <summary>
@@ -486,7 +483,7 @@ public class MemoryRepository : IRepository
     {
         Saving?.Invoke(this, new SaveEventArgs(oTableWrapperObject));
 
-        var typeDict = GetTypeDictionaryOrThrow(oTableWrapperObject.GetType());
+        var typeDict = GetOrCreateTypeDictionary(oTableWrapperObject.GetType());
 
         // If saving a new reference to an existing object then we should update our tracked
         // objects to the latest reference since the old one is stale

--- a/Rdmp.Core/Repositories/YamlRepository.cs
+++ b/Rdmp.Core/Repositories/YamlRepository.cs
@@ -123,7 +123,7 @@ public class YamlRepository : MemoryDataExportRepository
                         obj.PropertyChanged += toCreate_PropertyChanged;
 
                         // Use type-indexed storage instead of Objects
-                        GetTypeDictionaryOrThrow(t).TryAdd(obj.ID, obj);
+                        GetOrCreateTypeDictionary(t).TryAdd(obj.ID, obj);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
## Summary

Pre-populate `_objectsByType` with all compatible types at construction and freeze it for optimal read performance. Type hierarchy is also precomputed once at construction, eliminating runtime invalidation.

## Changes

- Replace `ConcurrentDictionary<Type, ConcurrentDictionary<...>>` with `FrozenDictionary` for the outer dictionary
- Pre-populate all ~100 compatible types at construction time
- Build type hierarchy once at construction (no more lazy invalidation)
- Simplify code by removing `GetOrCreateTypeDictionary` in favor of direct `GetTypeDictionary` lookups

## Benefits

- O(1) lookups with better cache locality on the outer dictionary
- No lock contention on `GetOrAdd` for type dictionary access
- Simpler code without dynamic type registration
- ~100 empty `ConcurrentDictionary` allocations per repository is negligible given repositories are rarely created

## Test plan

- [ ] Existing MemoryRepository tests pass
- [ ] YamlRepository tests pass (uses MemoryRepository as base)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the `MemoryRepository` by replacing the outer `ConcurrentDictionary` with a `FrozenDictionary` for type storage. All ~100 compatible types are pre-populated at construction time and the type hierarchy is precomputed once, eliminating the need for lazy initialization and runtime invalidation. This change improves read performance through better cache locality and O(1) lookups without lock contention, while simplifying the code by removing dynamic type registration logic in favor of direct dictionary lookups.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `Rdmp.Core/MapsDirectlyToDatabaseTable/MemoryRepository.cs` |
| 2 | `Rdmp.Core/Repositories/YamlRepository.cs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch MemoryRepository to a pre-populated type index with dynamic type support and a precomputed, frozen type hierarchy for faster lookups and simpler code. O(1) reads for known types; dynamic types are added on demand.

- **Refactors**
  - Keep outer ConcurrentDictionary; pre-populate all compatible types at construction and allow dynamic types (e.g., Spontaneous).
  - Build and freeze the interface/base type hierarchy at construction; remove lazy invalidation and locking.
  - Keep GetOrCreateTypeDictionary and add GetTypeDictionary; update YamlRepository to use GetOrCreateTypeDictionary.
  - Change Clear() to clear inner dictionaries while keeping the structure.

<sup>Written for commit 72b5b4977dbbefa43de616b25ca3ecd7cf52f1e0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







