### PR TITLE
Pin System.Security.Cryptography.Xml to fix GHSA-37gx-xxp4-5rgx

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,5 +38,7 @@
     <PackageVersion Include="DicomTypeTranslation" Version="5.0.1" />
     <PackageVersion Include="fo-dicom" Version="5.2.6" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <!-- Pin transitive dependency to fix GHSA-37gx-xxp4-5rgx (high severity in 8.0.2) -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- `System.Security.Cryptography.Xml` 8.0.2 is affected by [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) (high severity)
- This is a transitive dependency — no project in the solution references it directly
- With `CentralPackageTransitivePinningEnabled` set to `true` in `Directory.Build.props`, adding a `PackageVersion` entry pins the resolved version across all projects
- Pinned to 10.0.7 (latest stable, matching the project's net10.0 target framework)
- This eliminates the NU1903 audit warning that can break CI on projects with `TreatWarningsAsErrors` where `NoWarn` does not inherit properly from `Directory.Build.props`

## Test plan

- [ ] CI build passes with the new pin
- [ ] `dotnet list package --include-transitive --vulnerable` no longer reports System.Security.Cryptography.Xml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `System.Security.Cryptography.Xml` to 10.0.7 to fix GHSA-37gx-xxp4-5rgx present in 8.0.2. This also clears NU1903 vulnerability warnings that can fail CI with `TreatWarningsAsErrors`.

<sup>Written for commit 5cd7e5776e2629baf23817f4a85f21986d66a852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

