### PR TITLE
fix(deps): pin SQLitePCLRaw to 3.0.3 to fix CVE-2025-6965

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,5 +40,10 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <!-- Pin transitive dependency to fix GHSA-37gx-xxp4-5rgx (high severity in 8.0.2) -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <!-- Pin SQLitePCLRaw to 3.0.x to fix GHSA-2m69-gcr7-jv3q / CVE-2025-6965 (SQLite < 3.50.2).
+         3.0.x drops the vulnerable SQLitePCLRaw.lib.e_sqlite3 in favour of SourceGear.sqlite3 3.50.4.
+         Microsoft.Data.Sqlite 11.0 (with .NET 11, Nov 2026) will adopt this; until then we pin here. -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Fixes NU1903 build error: `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 has a known high severity vulnerability ([GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) / CVE-2025-6965).
- The vulnerable lib ships SQLite < 3.50.2 with a memory-corruption flaw via aggregate terms exceeding column count. No fix exists in the 2.1.x line.
- Pin `SQLitePCLRaw.bundle_e_sqlite3` and `SQLitePCLRaw.core` to 3.0.3 in `Directory.Packages.props`. With central package transitive pinning already enabled, this forces the chain `FAnsiSql.Legacy → FAnsiSql.Sqlite → Microsoft.Data.Sqlite 10.0.x → bundle_e_sqlite3` to resolve to 3.0.3, which uses `SourceGear.sqlite3` 3.50.4 (patched) and drops the vulnerable `lib.e_sqlite3` entirely.

## Why not suppress NU1903?

Real CVE; preferable to ship the patched native lib than to mask the warning.

## Why not wait for `Microsoft.Data.Sqlite` 11.0?

11.0 ships with .NET 11 in November 2026 (~5 months out). Currently at Preview 5. Not waiting that long with CI red.

## Why is the SQLitePCLRaw 2.x → 3.x major bump safe?

`Rdmp.Core/Startup/Startup.cs` registers only the MS SQL / MySQL / Oracle / PostgreSQL FAnsi implementations; the SQLite implementation is pulled in transitively via `FAnsiSql.Legacy` but is never `ImplementationManager.Load`-ed and the native bridge is therefore never invoked at runtime.

## Test plan

- [x] `dotnet restore` succeeds for `Rdmp.Core.csproj`
- [x] `dotnet nuget why Rdmp.Core SQLitePCLRaw.lib.e_sqlite3` reports no dependency
- [x] `dotnet build Rdmp.Core -c Release` succeeds with 0 errors
- [x] `dotnet build Rdmp.Core.Tests -c Release` succeeds with 0 errors
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `SQLitePCLRaw.bundle_e_sqlite3` and `SQLitePCLRaw.core` to 3.0.3 to remove the vulnerable `SQLitePCLRaw.lib.e_sqlite3` and resolve NU1903. This adopts `SourceGear.sqlite3` 3.50.4 and fixes CVE-2025-6965 (GHSA-2m69-gcr7-jv3q).

- **Dependencies**
  - Pinned `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 and `SQLitePCLRaw.core` 3.0.3 in `Directory.Packages.props`.
  - Central pin forces `FAnsiSql.Legacy → FAnsiSql.Sqlite → Microsoft.Data.Sqlite` to resolve to 3.0.3.
  - Drops `lib.e_sqlite3`; uses `SourceGear.sqlite3` 3.50.4 (patched).
  - Safe bump: the SQLite implementation is not loaded at runtime in `Rdmp.Core`.

- **Bug Fixes**
  - Fixes NU1903 build error for `SQLitePCLRaw.lib.e_sqlite3` (high severity vulnerability).

<sup>Written for commit 0c62621ab7fd1a71a8c09bc15448e74e1c4cd3cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jas88/RDMP/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

